### PR TITLE
Fix getCorrelationId when x-correlation-id header is set to null

### DIFF
--- a/src/Serializer/DomainSerializer.php
+++ b/src/Serializer/DomainSerializer.php
@@ -43,7 +43,9 @@ abstract class DomainSerializer implements SerializerInterface
 
     private function getCorrelationId(array $encodedEnvelope): string
     {
-        if (false !== \array_key_exists('x-correlation-id', $encodedEnvelope['headers'])) {
+        if (false !== \array_key_exists('x-correlation-id', $encodedEnvelope['headers'])
+            && null !== $encodedEnvelope['headers']['x-correlation-id']
+        ) {
             return $encodedEnvelope['headers']['x-correlation-id'];
         }
 


### PR DESCRIPTION
When I publish a domain event being the entrypoint a symfony console command (cli), the message got to RabbitMQ with the following headers:
```
x-correlation-id: undefined
x-reply-to:	  undefined
content_type:	  application/json
```
The culprit is on encoding at `AggregateMessageSerializer::encode` Line 57

Then `messenger:consume` process fails on `decode` and the worker quits unexpectedly.
```
In DomainSerializer.php line 47:
  PcComponentes\SymfonyMessengerBundle\Serializer\DomainSerializer::getCorrelationId(): Return value must be of type string, null returned
```
When called by `DomainSerializer::decode`.

The process reaches FATAL state in process manager (supervisord) after too many attempts to bring it up.

Altough there's still something wrong with the serializer when used by cli, the workers should not fail when the encoder gets a `x-correlation-id: ` header.