### PR TITLE
Fix problems when not providing a value for x-correlation-id header

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,15 @@
+name: Test
+on:
+  pull_request:
+    branches:
+      - master
+jobs:
+  phpunit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+        name: 'Run checkout'
+      - run: make cache-folders build composer-install
+        name: 'Build environment'
+      - run: make tests
+        name: 'Run unit tests'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,9 @@
 FROM php:8.0-cli-alpine3.13
 
-RUN apk update && \
-    apk add --no-cache \
-        libzip-dev \
-        openssl-dev && \
-    docker-php-ext-install -j$(nproc) \
-        zip
+RUN apk update \
+    && apk add --no-cache $PHPIZE_DEPS libzip-dev openssl-dev \
+    && docker-php-ext-install -j$(nproc) zip \
+    && pecl install xdebug-3.1.3 && docker-php-ext-enable xdebug
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer
 

--- a/Makefile
+++ b/Makefile
@@ -22,3 +22,7 @@ bash:
 
 logs:
 		docker-compose logs -f ${DOCKER_PHP_SERVICE}
+
+.PHONY: tests
+tests:
+		docker-compose run --rm -u ${UID}:${GID} ${DOCKER_PHP_SERVICE} phpunit

--- a/composer.json
+++ b/composer.json
@@ -18,13 +18,25 @@
       "PcComponentes\\SymfonyMessengerBundle\\": "src/"
     }
   },
+  "autoload-dev": {
+    "psr-4": {
+      "PcComponentes\\SymfonyMessengerBundle\\Tests\\": "tests/"
+    }
+  },
   "require": {
     "php": "^7.4 | ^8.0",
     "pccomponentes/ddd-logging": "^2.1",
     "pccomponentes/ddd": "^2.0",
-    "beberlei/assert": "^3.2"
+    "beberlei/assert": "^3.2",
+    "ramsey/uuid": "^3.7"
   },
   "require-dev": {
-    "pccomponentes/coding-standard": "^1.0"
+    "pccomponentes/coding-standard": "^1.0",
+    "phpunit/phpunit": "^9"
+  },
+  "config": {
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,8 @@ version: '3.7'
 
 services:
   php:
+    environment:
+      - XDEBUG_MODE=coverage
     build: .
     volumes:
       - .:/var/app

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!-- https://phpunit.de/manual/current/en/appendixes.configuration.html -->
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.0/phpunit.xsd"
+         backupGlobals="false"
+         colors="true"
+         bootstrap="tests/bootstrap.php"
+         cacheResult="false"
+>
+    <coverage includeUncoveredFiles="true"
+              processUncoveredFiles="true"
+              ignoreDeprecatedCodeUnits="true"
+              disableCodeCoverageIgnore="true">
+        <include>
+            <directory suffix=".php">./src/Bus</directory>
+            <directory suffix=".php">./src/Middleware</directory>
+            <directory suffix=".php">./src/Serializer</directory>
+        </include>
+        <exclude>
+            <directory suffix=".php">./src/DependencyInjection</directory>
+        </exclude>
+        <report>
+            <text outputFile="php://stdout" showUncoveredFiles="false" showOnlySummary="true"/>
+        </report>
+    </coverage>
+    <testsuites>
+        <testsuite name="Bundle Test Suite">
+            <directory>tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/src/Serializer/DomainSerializer.php
+++ b/src/Serializer/DomainSerializer.php
@@ -6,6 +6,7 @@ namespace PcComponentes\SymfonyMessengerBundle\Serializer;
 use PcComponentes\Ddd\Domain\Model\ValueObject\Uuid;
 use PcComponentes\Ddd\Util\Message\Message;
 use PcComponentes\DddLogging\DomainTrace\Tracker;
+use Ramsey\Uuid\Uuid as RamseyUuid;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
 use Symfony\Component\Messenger\Transport\Serialization\SerializerInterface;
@@ -61,7 +62,10 @@ abstract class DomainSerializer implements SerializerInterface
 
     private function getCorrelationId(array $encodedEnvelope): string
     {
-        if (false !== \array_key_exists('x-correlation-id', $encodedEnvelope['headers'])) {
+        if (false !== \array_key_exists('x-correlation-id', $encodedEnvelope['headers'])
+            && true === \is_string($encodedEnvelope['headers']['x-correlation-id'])
+            && true === RamseyUuid::isValid($encodedEnvelope['headers']['x-correlation-id'])
+        ) {
             return $encodedEnvelope['headers']['x-correlation-id'];
         }
 

--- a/tests/Mock/EventMock.php
+++ b/tests/Mock/EventMock.php
@@ -1,0 +1,43 @@
+<?php declare(strict_types=1);
+
+namespace PcComponentes\SymfonyMessengerBundle\Tests\Mock;
+
+use PcComponentes\Ddd\Domain\Model\DomainEvent;
+use PcComponentes\Ddd\Domain\Model\ValueObject\DateTimeValueObject;
+use PcComponentes\Ddd\Domain\Model\ValueObject\Uuid;
+
+final class EventMock extends DomainEvent
+{
+    private const NAME = 'event_mock';
+    private const VERSION = '1';
+
+    public static function from(Uuid $aggregateId): self {
+        return self::fromPayload(
+            Uuid::v4(),
+            $aggregateId,
+            new DateTimeValueObject(),
+            [],
+            0,
+        );
+    }
+
+    public static function messageName(): string
+    {
+        return 'pccomponentes.'
+            .'service.'
+            .self::VERSION.'.'
+            .self::messageType().'.'
+            .'aggregate.'
+            .self::NAME;
+    }
+
+    public static function messageVersion(): string
+    {
+        return self::VERSION;
+    }
+
+    protected function assertPayload(): void
+    {
+
+    }
+}

--- a/tests/Serializer/AggregateMessageSerialiazerTest.php
+++ b/tests/Serializer/AggregateMessageSerialiazerTest.php
@@ -1,0 +1,128 @@
+<?php
+declare(strict_types=1);
+
+namespace PcComponentes\SymfonyMessengerBundle\Tests\Serializer;
+
+use PcComponentes\Ddd\Domain\Model\ValueObject\Uuid;
+use PcComponentes\Ddd\Util\Message\Serialization\JsonApi\AggregateMessageJsonApiSerializable;
+use PcComponentes\Ddd\Util\Message\Serialization\JsonApi\AggregateMessageStreamDeserializer;
+use PcComponentes\Ddd\Util\Message\Serialization\MessageMappingRegistry;
+use PcComponentes\DddLogging\DomainTrace\Tracker;
+use PcComponentes\SymfonyMessengerBundle\Serializer\AggregateMessageSerializer;
+use PcComponentes\SymfonyMessengerBundle\Tests\Mock\EventMock;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid as RamseyUuid;
+
+final class AggregateMessageSerialiazerTest extends TestCase
+{
+    private Tracker $tracker;
+    private AggregateMessageSerializer $serializer;
+
+    public function setUp(): void
+    {
+        $this->tracker = new Tracker();
+
+        $registry = new MessageMappingRegistry([
+            EventMock::messageName() => EventMock::class
+        ]);
+        $aggregateMessageJsonApiSerializable = new AggregateMessageJsonApiSerializable();
+        $aggregateMessageStreamDeserializer = new AggregateMessageStreamDeserializer($registry);
+
+        $this->serializer = new AggregateMessageSerializer(
+            $this->tracker,
+            $aggregateMessageJsonApiSerializable,
+            $aggregateMessageStreamDeserializer
+        );
+
+        parent::setUp();
+    }
+
+    /**
+     * @test
+     */
+    public function given_valid_correlation_id_in_encoded_envelope_then_is_used()
+    {
+        $messageId = Uuid::v4();
+        $aggregateId = Uuid::v4();
+        $correlationId = Uuid::v4();
+        $encodedEnvelope = $this->buildEncodedEnvelope($correlationId->value(), $messageId, $aggregateId);
+
+        /** @var EventMock $message */
+        $message = $this->serializer->decode($encodedEnvelope)->getMessage();
+
+        $this->assertEquals($messageId, $message->messageId());
+        $this->assertEquals($correlationId, $this->tracker->correlationId($messageId));
+        $this->assertNull($this->tracker->replyTo($messageId));
+    }
+
+    /**
+     * @test
+     */
+    public function given_no_correlation_id_key_in_encoded_envelope_then_new_one_is_generated()
+    {
+        $messageId = Uuid::v4();
+        $aggregateId = Uuid::v4();
+        $encodedEnvelope = $this->buildEncodedEnvelope(false, $messageId, $aggregateId);
+
+        /** @var EventMock $message */
+        $message = $this->serializer->decode($encodedEnvelope)->getMessage();
+
+        $this->assertEquals($messageId, $message->messageId());
+        $this->assertTrue(RamseyUuid::isValid($this->tracker->correlationId($messageId)));
+        $this->assertNull($this->tracker->replyTo($messageId));
+    }
+
+    /**
+     * @test
+     */
+    public function given_null_correlation_id_in_encoded_envelope_then_new_one_is_generated()
+    {
+        $messageId = Uuid::v4();
+        $aggregateId = Uuid::v4();
+        $encodedEnvelope = $this->buildEncodedEnvelope(null, $messageId, $aggregateId);
+
+        /** @var EventMock $message */
+        $message = $this->serializer->decode($encodedEnvelope)->getMessage();
+
+        $this->assertEquals($messageId, $message->messageId());
+        $this->assertTrue(RamseyUuid::isValid($this->tracker->correlationId($messageId)));
+        $this->assertNull($this->tracker->replyTo($messageId));
+    }
+
+    /**
+     * @test
+     */
+    public function given_invalid_correlation_id_in_encoded_envelope_then_new_one_is_generated()
+    {
+        $messageId = Uuid::v4();
+        $aggregateId = Uuid::v4();
+        $encodedEnvelope = $this->buildEncodedEnvelope("FAKE_UUID", $messageId, $aggregateId);
+
+        /** @var EventMock $message */
+        $message = $this->serializer->decode($encodedEnvelope)->getMessage();
+
+        $this->assertEquals($messageId, $message->messageId());
+        $this->assertTrue(RamseyUuid::isValid($this->tracker->correlationId($messageId)));
+        $this->assertNull($this->tracker->replyTo($messageId));
+    }
+
+    private function buildEncodedEnvelope($correlationId, Uuid $messageId, Uuid $aggregateId): array
+    {
+        $encodedEnvelope = [
+            'headers' => [],
+            'body' => \json_encode([
+                'message_id' => $messageId->value(),
+                'aggregate_id' => $aggregateId->value(),
+                'name' => EventMock::messageName(),
+                'payload' => [],
+                'occurred_on' => (new \DateTimeImmutable)->format(\DateTimeInterface::ATOM),
+            ]),
+        ];
+
+        if ($correlationId !== false) {
+            $encodedEnvelope['headers']['x-correlation-id'] = $correlationId;
+        }
+
+        return $encodedEnvelope;
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,4 @@
+<?php
+declare(strict_types=1);
+
+require dirname(__DIR__).'/vendor/autoload.php';


### PR DESCRIPTION
Este PR intenta resolver el problema de no aportar un valor para `correlationId`, por ejemplo al lanzar un evento desde un comando en CLI, que provoca el siguiente problema:

![image](https://user-images.githubusercontent.com/1301633/157309081-d20cd30d-fb3b-4306-8596-5ceb2131634b.png)

```
In DomainSerializer.php line 65:
Return value of PcComponentes\SymfonyMessengerBundle\Serializer\DomainSerializer::getCorrelationId() must be of the type string, null returned
```

```
#0 /var/www/html/vendor/pccomponentes/messenger-bundle/src/Serializer/DomainSerializer.php(30): PcComponentes\SymfonyMessengerBundle\Serializer\DomainSerializer->getCorrelationId(Array)
#1 /var/www/html/vendor/pccomponentes/messenger-bundle/src/Serializer/AggregateMessageSerializer.php(45): PcComponentes\SymfonyMessengerBundle\Serializer\DomainSerializer->obtainDomainTrace(Object(BlablablablaEventCreated), Array)
#2 /var/www/html/vendor/symfony/messenger/Transport/AmqpExt/AmqpReceiver.php(66): PcComponentes\SymfonyMessengerBundle\Serializer\AggregateMessageSerializer->decode(Array)\n
#3 /var/www/html/vendor/symfony/messenger/Transport/AmqpExt/AmqpReceiver.php(45): Symfony\Component\Messenger\Transport\AmqpExt\AmqpReceiver->getEnvelope('events')\n
#4 /var/www/html/vendor/symfony/messenger/Worker.php(78): Symfony\Component\Messenger\Transport\AmqpExt\AmqpReceiver->get()\n
#5 /var/www/html/vendor/symfony/messenger/Command/ConsumeMessagesCommand.php(202): Symfony\Component\Messenger\Worker->run(Array)\n
#6 /var/www/html/vendor/symfony/console/Command/Command.php(255): Symfony\Component\Messenger\Command\ConsumeMessagesCommand->execute(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Consol
#7 /var/www/html/vendor/symfony/console/Application.php(1027): Symfony\Component\Console\Command\Command->run(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))\n
#8 /var/www/html/vendor/symfony/framework-bundle/Console/Application.php(97): Symfony\Component\Console\Application->doRunCommand(Object(Symfony\Component\Messenger\Command\ConsumeMessagesCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))\n
#9 /var/www/html/vendor/symfony/console/Application.php(273): Symfony\Bundle\FrameworkBundle\Console\Application->doRunCommand(Object(Symfony\Component\Messenger\Command\ConsumeMessagesCommand), Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))\n
#10 /var/www/html/vendor/symfony/framework-bundle/Console/Application.php(83): Symfony\Component\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))\n
#11 /var/www/html/vendor/symfony/console/Application.php(149): Symfony\Bundle\FrameworkBundle\Console\Application->doRun(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))\n
#12 /var/www/html/bin/console(29): Symfony\Component\Console\Application->run()\n
#13 {main}
```

Adicionalmente hemos incluído tests unitarios y un workflow para su ejecución en Gitlab.