### PR TITLE
Setting correct value for the RedeliveryStamp when not using Symfony retry logic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
 FROM php:8.0-cli-alpine3.13
 
+ADD https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin
 RUN apk update \
-    && apk add --no-cache $PHPIZE_DEPS libzip-dev openssl-dev \
-    && docker-php-ext-install -j$(nproc) zip \
-    && pecl install xdebug-3.1.3 && docker-php-ext-enable xdebug
-
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer
+    && chmod +x /usr/local/bin/install-php-extensions \
+    && /usr/local/bin/install-php-extensions amqp-stable zip-stable xdebug-stable \
+    && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin/ --filename=composer
 
 ENV PATH /var/app/bin:/var/app/vendor/bin:$PATH
 

--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
     }
   },
   "require": {
+    "ext-amqp": "*",
     "php": "^7.4 | ^8.0",
     "pccomponentes/ddd-logging": "^2.1",
     "pccomponentes/ddd": "^2.0",

--- a/src/Serializer/AggregateMessageSerializer.php
+++ b/src/Serializer/AggregateMessageSerializer.php
@@ -44,7 +44,10 @@ final class AggregateMessageSerializer extends DomainSerializer
 
         $this->obtainDomainTrace($aggregateMessage, $encodedEnvelope);
 
-        $retryCount = $this->extractHeaderRetryCount($encodedEnvelope);
+        $retryCount = \max(
+            $this->extractHeaderRetryCount($encodedEnvelope),
+            $this->buildRetryCountFromDeathHeader($encodedEnvelope),
+        );
 
         return (new Envelope($aggregateMessage))->with(new RedeliveryStamp($retryCount));
     }

--- a/src/Serializer/DomainSerializer.php
+++ b/src/Serializer/DomainSerializer.php
@@ -53,10 +53,33 @@ abstract class DomainSerializer implements SerializerInterface
         return (int) $encodedEnvelope['headers']['x-retry-count'];
     }
 
+    protected function buildRetryCountFromDeathHeader(array $encodedEnvelope): int
+    {
+        if (false === \array_key_exists('x-death', $encodedEnvelope['headers'])) {
+            return 0;
+        }
+
+        if (false === \is_array($encodedEnvelope['headers']['x-death'])) {
+            return 0;
+        }
+
+        if (0 === \count($encodedEnvelope['headers']['x-death'])) {
+            return 0;
+        }
+
+        $death = array_slice($encodedEnvelope['headers']['x-death'], 0, 1)[0];
+
+        if (false === \array_key_exists('count', $death)) {
+            return 0;
+        }
+
+        return (int) $death['count'];
+    }
+
     protected function extractEnvelopeRetryCount(Envelope $envelope): int
     {
         $retryCountStamp = $envelope->last(RedeliveryStamp::class);
-        
+
         return null !== $retryCountStamp ? $retryCountStamp->getRetryCount() : 0;
     }
 

--- a/src/Serializer/SimpleMessageSerializer.php
+++ b/src/Serializer/SimpleMessageSerializer.php
@@ -41,7 +41,10 @@ final class SimpleMessageSerializer extends DomainSerializer
 
         $this->obtainDomainTrace($simpleMessage, $encodedEnvelope);
 
-        $retryCount = $this->extractHeaderRetryCount($encodedEnvelope);
+        $retryCount = \max(
+            $this->extractHeaderRetryCount($encodedEnvelope),
+            $this->buildRetryCountFromDeathHeader($encodedEnvelope),
+        );
 
         return (new Envelope($simpleMessage))->with(new RedeliveryStamp($retryCount));
     }

--- a/tests/Mock/CommandMock.php
+++ b/tests/Mock/CommandMock.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace PcComponentes\SymfonyMessengerBundle\Tests\Mock;
+
+use PcComponentes\Ddd\Application\Command;
+
+final class CommandMock extends Command
+{
+    private const NAME = 'command_mock';
+    private const VERSION = '1';
+
+    public static function messageName(): string
+    {
+        return 'pccomponentes.'
+            .'service.'
+            .self::VERSION.'.'
+            .self::messageType().'.'
+            .'aggregate.'
+            .self::NAME;
+    }
+
+    public static function messageVersion(): string
+    {
+        return self::VERSION;
+    }
+
+    protected function assertPayload(): void
+    {
+
+    }
+}


### PR DESCRIPTION
Symfony Messenger can [handle failed and retry logic for failed messages](https://symfony.com/doc/current/messenger.html#retries-failures), but in some of the PcComponentes services we have this kind of Symfony Messenger configuration, where is RabbitMQ who manages when to redeliver a message to a queue, as failed commands are routed by RabbitMQ to the dead_letter when an Exception is thrown within the worker.

```yaml
      commands:
        options:
          exchange:
            name: commands
            type: fanout
          queues:
            commands:
              binding_keys:
                - '*.*.*.command.*.*'
              arguments:
                x-dead-letter-exchange: dead_letter
        retry_strategy:
          max_retries: 0

      dead_letter:
        options:
          exchange:
            name: dead_letter
            type: topic
          queues:
            commands.dead_letter:
              binding_keys:
                - '*.*.*.command.*.*'
              arguments:
                x-message-ttl: 300000
                x-dead-letter-exchange: commands
```

In these cases, the `x-retry-count` header is never filled so we can not analyze in our logging systems commands that have failed several times.

This PR fixes this, as it also looks for the [`x-death` header](https://www.rabbitmq.com/dlx.html#effects) set by RabbitMQ when decoding a message.

# Examples

## Pristine message (Never has been delivered)
![image](https://user-images.githubusercontent.com/1301633/158075964-dd614abb-daf9-4c4f-9500-8c1a243c3ce7.png)

## Failed message (Delivered once and now it stays in the dead_letter queue)
![image](https://user-images.githubusercontent.com/1301633/158076070-41500015-f118-4bf4-857c-262262e871ab.png)

## Failed message (Sent to the dead_letter and back again to the main queue)
![image](https://user-images.githubusercontent.com/1301633/158076362-b2eecb64-6b59-4406-a891-643c2db872f0.png)
