### PR TITLE
Fix rejection logic is not being called after an invalid message has been received

### DIFF
--- a/src/Serializer/AggregateMessageSerializer.php
+++ b/src/Serializer/AggregateMessageSerializer.php
@@ -42,7 +42,7 @@ final class AggregateMessageSerializer extends DomainSerializer
         } catch (MessageClassNotFoundException $exception) {
             throw new MessageDecodingFailedException('Message class not found', 0, $exception);
         } catch (Throwable $exception) {
-            throw new MessageDecodingFailedException('Unable to instantiate class for message' . $exception->getMessage(), 0, $exception);
+            throw new MessageDecodingFailedException('Unable to instantiate class for message. ' . $exception->getMessage(), 0, $exception);
         }
 
         $this->obtainDomainTrace($aggregateMessage, $encodedEnvelope);

--- a/src/Serializer/AggregateMessageSerializer.php
+++ b/src/Serializer/AggregateMessageSerializer.php
@@ -13,6 +13,7 @@ use PcComponentes\DddLogging\DomainTrace\Tracker;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
 use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
+use Throwable;
 
 final class AggregateMessageSerializer extends DomainSerializer
 {
@@ -39,7 +40,9 @@ final class AggregateMessageSerializer extends DomainSerializer
         try {
             $aggregateMessage = $this->deserializer->unserialize($message);
         } catch (MessageClassNotFoundException $exception) {
-            throw new MessageDecodingFailedException();
+            throw new MessageDecodingFailedException('Message class not found', 0, $exception);
+        } catch (Throwable $exception) {
+            throw new MessageDecodingFailedException('Unable to instantiate class for message' . $exception->getMessage(), 0, $exception);
         }
 
         $this->obtainDomainTrace($aggregateMessage, $encodedEnvelope);

--- a/src/Serializer/SimpleMessageSerializer.php
+++ b/src/Serializer/SimpleMessageSerializer.php
@@ -39,7 +39,7 @@ final class SimpleMessageSerializer extends DomainSerializer
         } catch (MessageClassNotFoundException $exception) {
             throw new MessageDecodingFailedException('Message class not found', 0, $exception);
         } catch (Throwable $exception) {
-            throw new MessageDecodingFailedException('Unable to instantiate class for message' . $exception->getMessage(), 0, $exception);
+            throw new MessageDecodingFailedException('Unable to instantiate class for message. ' . $exception->getMessage(), 0, $exception);
         }
 
         $this->obtainDomainTrace($simpleMessage, $encodedEnvelope);

--- a/src/Serializer/SimpleMessageSerializer.php
+++ b/src/Serializer/SimpleMessageSerializer.php
@@ -12,6 +12,7 @@ use PcComponentes\DddLogging\DomainTrace\Tracker;
 use Symfony\Component\Messenger\Envelope;
 use Symfony\Component\Messenger\Exception\MessageDecodingFailedException;
 use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
+use Throwable;
 
 final class SimpleMessageSerializer extends DomainSerializer
 {
@@ -36,7 +37,9 @@ final class SimpleMessageSerializer extends DomainSerializer
         try {
             $simpleMessage = $this->deserializer->unserialize($message);
         } catch (MessageClassNotFoundException $exception) {
-            throw new MessageDecodingFailedException();
+            throw new MessageDecodingFailedException('Message class not found', 0, $exception);
+        } catch (Throwable $exception) {
+            throw new MessageDecodingFailedException('Unable to instantiate class for message' . $exception->getMessage(), 0, $exception);
         }
 
         $this->obtainDomainTrace($simpleMessage, $encodedEnvelope);


### PR DESCRIPTION
When a transport receives a message, `AggregateMessageSerializer` or `SimpleMessageSerializer` tries to unserialize it, verifying its properties.

When the `fromPayload` method is called, exceptions are never chained inside a `MessageDecodingFailedException`, so the rejection logic does not get called by the receiver, for example in the AmqpReceiver (https://github.com/symfony/amqp-messenger/blob/5.1/Transport/AmqpReceiver.php#L68)

As the message never abandons the transport, it gets redelivered forever blocking the consumers:

```bash
loop console messenger:consume commands --bus=messenger.bus.command
```

![screen-capture](https://user-images.githubusercontent.com/1301633/159039632-f61c992d-276d-48e3-88b5-b2c1bce016c8.gif)

![image](https://user-images.githubusercontent.com/1301633/159040024-81de01f5-f7f7-4001-8e92-cd13beed828a.png)

This PR fixes this, throwing a `MessageDecodingFailedException` with its previous exception in the chain, so the failed messages are routed to the rejection path, for example a dead letter exchange.

![image](https://user-images.githubusercontent.com/1301633/159041319-8c0b90f3-15a1-4263-8192-891cf113e07f.png)
