### PR TITLE
Allow multiple messages to be returned on converters

### DIFF
--- a/src/Bus/AllHandledStampExtractor.php
+++ b/src/Bus/AllHandledStampExtractor.php
@@ -19,7 +19,6 @@ final class AllHandledStampExtractor implements MessageResultExtractor
 
             foreach ($stamp as $resultStamp) {
                 \assert($resultStamp instanceof HandledStamp);
-
                 $results[] = $resultStamp->getResult();
             }
         }

--- a/src/Bus/AllHandledStampExtractor.php
+++ b/src/Bus/AllHandledStampExtractor.php
@@ -19,6 +19,7 @@ final class AllHandledStampExtractor implements MessageResultExtractor
 
             foreach ($stamp as $resultStamp) {
                 \assert($resultStamp instanceof HandledStamp);
+
                 $results[] = $resultStamp->getResult();
             }
         }

--- a/src/Middleware/SimpleMessagePublisherMiddleware.php
+++ b/src/Middleware/SimpleMessagePublisherMiddleware.php
@@ -40,6 +40,10 @@ final class SimpleMessagePublisherMiddleware implements MiddlewareInterface
             }
 
             foreach ($commands as $theCommand) {
+                if (false === \is_object($theCommand)) {
+                    continue;
+                }
+
                 $this->messageBroker->dispatch($theCommand);
             }
         }

--- a/src/Middleware/SimpleMessagePublisherMiddleware.php
+++ b/src/Middleware/SimpleMessagePublisherMiddleware.php
@@ -40,10 +40,6 @@ final class SimpleMessagePublisherMiddleware implements MiddlewareInterface
             }
 
             foreach ($commands as $theCommand) {
-                if (null === $theCommand) {
-                    continue;
-                }
-
                 $this->messageBroker->dispatch($theCommand);
             }
         }

--- a/src/Middleware/SimpleMessagePublisherMiddleware.php
+++ b/src/Middleware/SimpleMessagePublisherMiddleware.php
@@ -23,28 +23,28 @@ final class SimpleMessagePublisherMiddleware implements MiddlewareInterface
     public function handle(Envelope $envelope, StackInterface $stack): Envelope
     {
         $resultStack = $stack->next()->handle($envelope, $stack);
-        $commandsToBeDispatched = $this->extractor->extract($resultStack);
+        $convertersResult = $this->extractor->extract($resultStack);
 
-        if (null === $commandsToBeDispatched || (\is_countable($commandsToBeDispatched) && 0 === \count($commandsToBeDispatched))) {
+        if (null === $convertersResult || (\is_countable($convertersResult) && 0 === \count($convertersResult))) {
             return $resultStack;
         }
 
-        foreach ($commandsToBeDispatched as $command) {
-            if (null === $command) {
+        foreach ($convertersResult as $commands) {
+            if (null === $commands) {
                 continue;
             }
 
-            // We can accept an array of commands to be executed
-            if (true === \is_array($command)) {
-                foreach ($command as $singleCommand) {
-                    if (null === $singleCommand) {
-                        continue;
-                    }
+            // We can accept both one or an array of commands to be dispatched
+            if (false === \is_array($commands)) {
+                $commands = [$commands];
+            }
 
-                    $this->messageBroker->dispatch($singleCommand);
+            foreach ($commands as $theCommand) {
+                if (null === $theCommand) {
+                    continue;
                 }
-            } else {
-                $this->messageBroker->dispatch($command);
+
+                $this->messageBroker->dispatch($theCommand);
             }
         }
 

--- a/src/Middleware/SimpleMessagePublisherMiddleware.php
+++ b/src/Middleware/SimpleMessagePublisherMiddleware.php
@@ -23,13 +23,13 @@ final class SimpleMessagePublisherMiddleware implements MiddlewareInterface
     public function handle(Envelope $envelope, StackInterface $stack): Envelope
     {
         $resultStack = $stack->next()->handle($envelope, $stack);
-        $convertersResult = $this->extractor->extract($resultStack);
+        $commandsResult = $this->extractor->extract($resultStack);
 
-        if (null === $convertersResult || (\is_countable($convertersResult) && 0 === \count($convertersResult))) {
+        if (null === $commandsResult || (\is_countable($commandsResult) && 0 === \count($commandsResult))) {
             return $resultStack;
         }
 
-        foreach ($convertersResult as $commands) {
+        foreach ($commandsResult as $commands) {
             if (null === $commands) {
                 continue;
             }

--- a/tests/Bus/AllHandledStampExtractorTest.php
+++ b/tests/Bus/AllHandledStampExtractorTest.php
@@ -1,0 +1,78 @@
+<?php
+declare(strict_types=1);
+
+namespace PcComponentes\SymfonyMessengerBundle\Tests\Bus;
+
+use PcComponentes\Ddd\Domain\Model\ValueObject\Uuid;
+use PcComponentes\Ddd\Util\Message\Serialization\JsonApi\SimpleMessageJsonApiSerializable;
+use PcComponentes\Ddd\Util\Message\Serialization\JsonApi\SimpleMessageStreamDeserializer;
+use PcComponentes\Ddd\Util\Message\Serialization\MessageMappingRegistry;
+use PcComponentes\DddLogging\DomainTrace\Tracker;
+use PcComponentes\SymfonyMessengerBundle\Bus\AllHandledStampExtractor;
+use PcComponentes\SymfonyMessengerBundle\Middleware\SimpleMessagePublisherMiddleware;
+use PcComponentes\SymfonyMessengerBundle\Serializer\SimpleMessageSerializer;
+use PcComponentes\SymfonyMessengerBundle\Tests\Mock\CommandMock;
+use PHPUnit\Framework\TestCase;
+use Ramsey\Uuid\Uuid as RamseyUuid;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Middleware\StackMiddleware;
+use Symfony\Component\Messenger\Stamp\HandledStamp;
+use Symfony\Component\Messenger\Stamp\RedeliveryStamp;
+
+final class AllHandledStampExtractorTest extends TestCase
+{
+    private AllHandledStampExtractor $extractor;
+
+    public function setUp(): void
+    {
+        $this->extractor = new AllHandledStampExtractor();
+
+        parent::setUp();
+    }
+
+    public function test_single_command_is_returned()
+    {
+        $envelope = new Envelope(new \stdClass());
+        $handledStamp = new HandledStamp(CommandMock::fromPayload(Uuid::v4(), []), 'handler');
+        $handledEnvelope = $envelope->with($handledStamp);
+
+        $results = $this->extractor->extract($handledEnvelope);
+
+        $this->assertCount(1, $results);
+        $this->assertInstanceOf(CommandMock::class, $results[0]);
+    }
+
+    public function test_single_and_multiple_command_are_returned()
+    {
+        $envelope = new Envelope(new \stdClass());
+        $firstCommandId = Uuid::v4();
+        $secondCommandId = Uuid::v4();
+        $thirdCommandId = Uuid::v4();
+
+        $firstConverterHandledStamp = new HandledStamp(
+            CommandMock::fromPayload($thirdCommandId, []),
+            'firstHandler'
+        );
+        $handledEnvelope = $envelope->with($firstConverterHandledStamp);
+
+        $secondConverterHandledStamp = new HandledStamp([
+            CommandMock::fromPayload($firstCommandId, []),
+            CommandMock::fromPayload($secondCommandId, []),
+        ], 'secondHandler');
+        $handledEnvelope = $handledEnvelope->with($secondConverterHandledStamp);
+
+        $results = $this->extractor->extract($handledEnvelope);
+
+        $this->assertCount(2, $results);
+
+        $this->assertInstanceOf(CommandMock::class, $results[0]);
+        $this->assertEquals($thirdCommandId, $results[0]->messageId());
+
+        $this->assertIsArray($results[1]);
+        $this->assertInstanceOf(CommandMock::class, $results[1][0]);
+        $this->assertEquals($firstCommandId, $results[1][0]->messageId());
+        $this->assertInstanceOf(CommandMock::class, $results[1][1]);
+        $this->assertEquals($secondCommandId, $results[1][1]->messageId());
+    }
+}

--- a/tests/Bus/AllHandledStampExtractorTest.php
+++ b/tests/Bus/AllHandledStampExtractorTest.php
@@ -31,7 +31,7 @@ final class AllHandledStampExtractorTest extends TestCase
         parent::setUp();
     }
 
-    public function test_single_command_is_returned()
+    public function test_given_single_command_is_returned_then_on()
     {
         $envelope = new Envelope(new \stdClass());
         $handledStamp = new HandledStamp(CommandMock::fromPayload(Uuid::v4(), []), 'handler');
@@ -43,7 +43,22 @@ final class AllHandledStampExtractorTest extends TestCase
         $this->assertInstanceOf(CommandMock::class, $results[0]);
     }
 
-    public function test_single_and_multiple_command_are_returned()
+    public function test_given_single_command_and_null_are_returned_then_on()
+    {
+        $envelope = new Envelope(new \stdClass());
+        $handledEnvelope = $envelope->with(
+            new HandledStamp(CommandMock::fromPayload(Uuid::v4(), []), 'converterA'),
+            new HandledStamp(null, 'converterB')
+        );
+
+        $results = $this->extractor->extract($handledEnvelope);
+
+        $this->assertCount(2, $results);
+        $this->assertInstanceOf(CommandMock::class, $results[0]);
+        $this->assertNull($results[1]);
+    }
+
+    public function test_given_single_and_multiple_command_are_returned_then_ok()
     {
         $envelope = new Envelope(new \stdClass());
         $firstCommandId = Uuid::v4();

--- a/tests/Middleware/SimpleMessagePublisherMiddlewareTest.php
+++ b/tests/Middleware/SimpleMessagePublisherMiddlewareTest.php
@@ -1,0 +1,75 @@
+<?php
+declare(strict_types=1);
+
+namespace PcComponentes\SymfonyMessengerBundle\Tests\Middleware;
+
+use PcComponentes\Ddd\Domain\Model\ValueObject\DateTimeValueObject;
+use PcComponentes\Ddd\Domain\Model\ValueObject\Uuid;
+use PcComponentes\SymfonyMessengerBundle\Bus\AllHandledStampExtractor;
+use PcComponentes\SymfonyMessengerBundle\Middleware\SimpleMessagePublisherMiddleware;
+use PcComponentes\SymfonyMessengerBundle\Tests\Mock\CommandMock;
+use PcComponentes\SymfonyMessengerBundle\Tests\Mock\EventMock;
+use PcComponentes\SymfonyMessengerBundle\Tests\Mock\FakeBus;
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+use Symfony\Component\Messenger\Stamp\HandledStamp;
+use Symfony\Component\Messenger\Test\Middleware\MiddlewareTestCase;
+
+final class SimpleMessagePublisherMiddlewareTest extends MiddlewareTestCase
+{
+    private MessageBusInterface $bus;
+    private AllHandledStampExtractor $extractor;
+
+    public function setUp(): void
+    {
+        $this->bus = new FakeBus();
+        $this->extractor = new AllHandledStampExtractor();
+
+        parent::setUp();
+    }
+
+    public function test_given_converters_dispatch_only_one_command_per_converter_then_ok()
+    {
+        $firstMessageId = Uuid::v4();
+        $secondMessageId = Uuid::v4();
+
+        $envelope = new Envelope(EventMock::fromPayload(Uuid::v4(), Uuid::v4(), DateTimeValueObject::now(), []));
+        $envelope = $envelope->with(
+            new HandledStamp(CommandMock::fromPayload($firstMessageId, []), 'ConverterA'),
+            new HandledStamp(CommandMock::fromPayload($secondMessageId, []), 'ConverterB'),
+        );
+
+        $middleware = new SimpleMessagePublisherMiddleware($this->bus, $this->extractor);
+        $middleware->handle($envelope, $this->getStackMock());
+
+        $this->assertCount(2, $this->bus->getMessages());
+        $this->assertEquals($firstMessageId, $this->bus->getMessages()[0]->getMessage()->messageId()->value());
+        $this->assertEquals($secondMessageId, $this->bus->getMessages()[1]->getMessage()->messageId()->value());
+    }
+
+    public function test_given_converters_dispatch_both_one_command_and_an_array_of_commands_then_ok()
+    {
+        $firstMessageId = Uuid::v4();
+        $secondMessageId = Uuid::v4();
+        $thirdMessageId = Uuid::v4();
+
+        $envelope = new Envelope(EventMock::fromPayload(Uuid::v4(), Uuid::v4(), DateTimeValueObject::now(), []));
+        $envelope = $envelope->with(
+            new HandledStamp(CommandMock::fromPayload($firstMessageId, []), 'ConverterA'),
+            new HandledStamp([
+                    CommandMock::fromPayload($secondMessageId, []),
+                    CommandMock::fromPayload($thirdMessageId, []),
+                ],
+                'ConverterB'
+            ),
+        );
+
+        $middleware = new SimpleMessagePublisherMiddleware($this->bus, $this->extractor);
+        $middleware->handle($envelope, $this->getStackMock());
+
+        $this->assertCount(3, $this->bus->getMessages());
+        $this->assertEquals($firstMessageId, $this->bus->getMessages()[0]->getMessage()->messageId()->value());
+        $this->assertEquals($secondMessageId, $this->bus->getMessages()[1]->getMessage()->messageId()->value());
+        $this->assertEquals($thirdMessageId, $this->bus->getMessages()[2]->getMessage()->messageId()->value());
+    }
+}

--- a/tests/Mock/FakeBus.php
+++ b/tests/Mock/FakeBus.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace PcComponentes\SymfonyMessengerBundle\Tests\Mock;
+
+use Symfony\Component\Messenger\Envelope;
+use Symfony\Component\Messenger\MessageBusInterface;
+
+final class FakeBus implements MessageBusInterface
+{
+    /** @var array<Envelope> */
+    private array $messages = [];
+
+    public function dispatch(object $message, array $stamps = []): Envelope
+    {
+        $envelope = Envelope::wrap($message, $stamps);
+        $this->messages[] = $envelope;
+
+        return $envelope;
+    }
+
+    /**
+     * @return array<Envelope>
+     */
+    public function getMessages(): array
+    {
+        return $this->messages;
+    }
+}


### PR DESCRIPTION
On Converters, we were only allowed to dispatch a single command, with this improvement you are now allowed to dispatch as many commands as you need using an array, for example:

```php
final class UpdateOfferViewWhenActivatedConverter implements MessageHandlerInterface
{
    public function __invoke(OfferActivated $event)
    {
        return [
            UpdateOfferViewCommand::fromPayload(
                Uuid::v4(),
                [
                    UpdateOfferViewCommand::OFFER_ID_KEY => $event->aggregateId()->value(),
                    UpdateOfferViewCommand::REASON_KEY => $event::NAME,
                ],
            ),
            IncreaseNumberOfActivatedOffersCommand::fromPayload(
                Uuid::v4(),
                [
                    UpdateNumberOfActivatedOffersCommand::OFFER_ID_KEY => $event->aggregateId()->value(),
                ],
            )
        ];
    }
}
```

All messages will be dispatched to the bus configured on the `SimpleMessagePublisherMiddleware`.