### PR TITLE
feat: Deserialize unsupported commands

### DIFF
--- a/src/Command/UnsupportedCommand.php
+++ b/src/Command/UnsupportedCommand.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+namespace PcComponentes\SymfonyMessengerBundle\Command;
+
+use PcComponentes\Ddd\Application\Command;
+use PcComponentes\Ddd\Domain\Model\ValueObject\Uuid;
+
+final class UnsupportedCommand extends Command
+{
+    private static string $messageName = 'unsupported';
+    private static string $messageVersion = '0';
+
+    public static function create(string $messageId, string $messageName, array $payload): self
+    {
+        $fields = \explode('.', $messageName);
+
+        self::$messageName = $messageName;
+        self::$messageVersion = $fields[2] ?? '1';
+
+        return self::fromPayload(
+            Uuid::from($messageId),
+            $payload,
+        );
+    }
+
+    public static function messageName(): string
+    {
+        return self::$messageName;
+    }
+
+    public static function messageVersion(): string
+    {
+        return self::$messageVersion;
+    }
+
+    protected function assertPayload(): void
+    {
+    }
+}


### PR DESCRIPTION
Currently, if a command arrives with a payload not supported for that deserialization class, it fails and [Symfony Messenger](https://github.com/symfony/messenger) discards the message (**losing itself**).

This change deserializes it into a generic "UnsupportedCommand" command that can be handled to throw an exception or make it a valid command to use Symfony Messenger's [retry policy](https://github.com/PcComponentes/messenger-retry-bundle).